### PR TITLE
Fix FBX naming bugs

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,7 +42,7 @@ class TkFbxNodeApp(sgtk.platform.Application):
 
         self.log_debug("Converting Toolkit fbx nodes to built-in fbx nodes.")
         tk_houdini_fbx = self.import_module("tk_houdini_fbx")
-        tk_houdini_fbx.TkfbxNodeHandler.convert_to_regular_fbx_nodes(self)
+        tk_houdini_fbx.TkFbxNodeHandler.convert_to_regular_fbx_nodes(self)
 
     def convert_back_to_tk_fbx_nodes(self):
         """Convert regular fbx nodes back to Tooklit fbx nodes.
@@ -63,7 +63,7 @@ class TkFbxNodeApp(sgtk.platform.Application):
             "Converting built-in fbx nodes back to Toolkit fbx nodes."
         )
         tk_houdini_fbx = self.import_module("tk_houdini_fbx")
-        tk_houdini_fbx.TkfbxNodeHandler.convert_back_to_tk_fbx_nodes(self)
+        tk_houdini_fbx.TkFbxNodeHandler.convert_back_to_tk_fbx_nodes(self)
 
     def get_nodes(self):
         """
@@ -79,7 +79,7 @@ class TkFbxNodeApp(sgtk.platform.Application):
 
         self.log_debug("Retrieving tk-houdini-fbx nodes...")
         tk_houdini_fbx = self.import_module("tk_houdini_fbx")
-        nodes = tk_houdini_fbx.TkfbxNodeHandler.get_all_tk_fbx_nodes()
+        nodes = tk_houdini_fbx.TkFbxNodeHandler.get_all_tk_fbx_nodes()
         self.log_debug("Found %s tk-houdini-fbx nodes." % (len(nodes),))
         return nodes
 
@@ -97,7 +97,7 @@ class TkFbxNodeApp(sgtk.platform.Application):
 
         self.log_debug("Retrieving output path for %s" % (node,))
         tk_houdini_fbx = self.import_module("tk_houdini_fbx")
-        output_path = tk_houdini_fbx.TkfbxNodeHandler.get_output_path(node)
+        output_path = tk_houdini_fbx.TkFbxNodeHandler.get_output_path(node)
         self.log_debug("Retrieved output path: %s" % (output_path,))
         return output_path
 

--- a/python/tk_houdini_fbx/handler.py
+++ b/python/tk_houdini_fbx/handler.py
@@ -37,7 +37,7 @@ class TkFbxNodeHandler(object):
     NODE_OUTPUT_PATH_PARM = "sopoutput"
     """The name of the output path parameter on the node."""
 
-    TK_FBX_NODE_TYPE = "sgtk_fbx_sop"
+    TK_FBX_NODE_TYPE = "sgtk_fbx"
     """The class of node as defined in Houdini for the fbx nodes."""
 
     TK_OUTPUT_CONNECTIONS_KEY = "tk_output_connections"
@@ -276,7 +276,7 @@ class TkFbxNodeHandler(object):
         tk_node_type = TkFbxNodeHandler.TK_FBX_NODE_TYPE
 
         # get all instances of tk fbx sop nodes
-        tk_fbx_nodes = hou.sopNodeTypeCategory().nodeType("sgtk_fbx_sop").instances()
+        tk_fbx_nodes = hou.sopNodeTypeCategory().nodeType(tk_node_type).instances()
         print(tk_fbx_nodes)
 
         return tk_fbx_nodes


### PR DESCRIPTION
TkFbxNodeHandler was still used as TkfbxNodeHandler in some places.
TK_FBX_NODE_TYPE was incorrect with new node version.